### PR TITLE
feat: check file permissions on all folders and files

### DIFF
--- a/.build/docker/Dockerfile
+++ b/.build/docker/Dockerfile
@@ -15,4 +15,4 @@ WORKDIR /app
 
 COPY --from=builder /app/build ./build
 
-CMD ["node", "./build/bundle.cjs", "run", "--network", "testnet"]
+CMD ["node", "./build/seda-overlay.cjs", "run", "--network", "testnet"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,16 +49,16 @@ jobs:
           patterns: |
             build/seda-overlay-linux-arm64
             build/seda-overlay-linux-x64
-            build/seda-overlay.js
+            build/seda-overlay.cjs
 
       - name: ⬆️ Upload JS artifact and checksum for release
         uses: actions/upload-artifact@v4
         with:
           name: release-assets
           path: |
-            build/seda-overlay.js
             build/seda-overlay-linux-arm64
             build/seda-overlay-linux-x64
+            build/seda-overlay.cjs
             checksum.txt
 
   build_and_push_docker_images:

--- a/build-node.ts
+++ b/build-node.ts
@@ -1,4 +1,4 @@
-import { rename } from "node:fs/promises";
+import { copyFile, rename } from "node:fs/promises";
 import path, { resolve } from "node:path";
 import { build } from "esbuild";
 import { SeaEsbuildPlugin } from "sea-plugin";
@@ -45,5 +45,7 @@ await build({
 		}),
 	],
 });
+
+await copyFile(path.join(outDir, "bundle.cjs"), path.join(outDir, "seda-overlay.cjs"));
 
 console.log("Built binaries");

--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
         "@hono/node-server": "1.14.1",
         "@seda-protocol/proto-messages": "0.5.0-dev.0",
         "@seda-protocol/utils": "1.3.0",
-        "@seda-protocol/vm": "^1.0.6",
+        "@seda-protocol/vm": "^1.0.7",
         "@sedaprotocol/core-contract-schema": "0.0.0",
         "@sedaprotocol/overlay-ts-common": "0.0.0",
         "@sedaprotocol/overlay-ts-config": "0.0.0",
@@ -244,7 +244,7 @@
 
     "@seda-protocol/utils": ["@seda-protocol/utils@1.3.0", "", { "peerDependencies": { "true-myth": "^8.0.1", "valibot": "^0.42.1" } }, "sha512-6/2qt7+TUQcezWwGHB3QdJZLfd8cRzS58UpdbqzAtRmy4jsM7AR5bcKqNrIjNNBIB/rX29ObaLjT3JK3G3Khkg=="],
 
-    "@seda-protocol/vm": ["@seda-protocol/vm@1.0.6", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.0", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-xK+tUaV1a1MCu8IkZfCRiMLDoQ9iDusy/qaLp9FuqiYBYhEQTBnt6+n0o/znszQ346QD7/W0c25IwHdygdIChg=="],
+    "@seda-protocol/vm": ["@seda-protocol/vm@1.0.7", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.0", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-rENrRpLSB/rrN7QU85OgiZx08JRh+9rwyiug/sDtXhi88cJqM5RxStUZeuKwoPaENeJF7PEzGIFElhEK09FxGA=="],
 
     "@seda-protocol/wasm-metering-ts": ["@seda-protocol/wasm-metering-ts@2.0.0", "", { "dependencies": { "buffer-pipe": "^0.0.5", "leb128": "^0.0.5", "warp-isomorphic": "^1.0.7" }, "peerDependencies": { "typescript": "^5.7.3" } }, "sha512-EA/xNeVG/yKiXw/zP+QL0q/Oq7cpee2ydpfmfOXMVgU0emEX2aHuSv1lHCNuw4vNVuN7sjzEUXKwUlkAAmBvaA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "overlay-node-ts",
 	"module": "index.ts",
-	"version": "1.0.0-rc.10",
+	"version": "1.0.0-rc.11",
 	"type": "module",
 	"license": "AGPL-3.0",
 	"workspaces": [

--- a/packages/config/src/check-permissions.ts
+++ b/packages/config/src/check-permissions.ts
@@ -1,0 +1,42 @@
+import { constants } from "node:fs";
+import { access, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tryAsync } from "@sedaprotocol/overlay-ts-common";
+import { logger } from "@sedaprotocol/overlay-ts-logger";
+import { Result, type Unit } from "true-myth";
+import type { AppConfig } from "./models/app-config";
+
+export async function checkFilePermissions(appConfig: AppConfig): Promise<Result<Unit, string>> {
+	logger.info("Checking file permissions..");
+	const wasmCacheDirAccess = await tryAsync<void>(() =>
+		access(appConfig.wasmCacheDir, constants.R_OK | constants.W_OK),
+	);
+	if (wasmCacheDirAccess.isErr) {
+		return Result.err(`Error checking permissions for ${appConfig.wasmCacheDir}: ${wasmCacheDirAccess.error}`);
+	}
+
+	const logsDirAccess = await tryAsync<void>(() => access(appConfig.logsDir, constants.R_OK | constants.W_OK));
+	if (logsDirAccess.isErr) {
+		return Result.err(`Error checking permissions for ${appConfig.logsDir}: ${logsDirAccess.error}`);
+	}
+
+	const workersDirAccess = await tryAsync<void>(() => access(appConfig.workersDir, constants.R_OK | constants.W_OK));
+	if (workersDirAccess.isErr) {
+		return Result.err(`Error checking permissions for ${appConfig.workersDir}: ${workersDirAccess.error}`);
+	}
+
+	// Just to make sure all the cache is still readable and the user didn't mess up..
+	const wasmCacheDirFiles = await readdir(appConfig.wasmCacheDir);
+	for (const file of wasmCacheDirFiles) {
+		const filePath = join(appConfig.wasmCacheDir, file);
+		const fileAccess = await tryAsync<void>(() => access(filePath, constants.R_OK));
+
+		if (fileAccess.isErr) {
+			return Result.err(`Error checking permissions for ${filePath}: ${fileAccess.error}`);
+		}
+	}
+
+	logger.info("File permissions check passed.");
+
+	return Result.ok();
+}

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -28,7 +28,8 @@ export const DEFAULT_HTTP_SERVER_PORT = 3000;
 export const DEFAULT_ADJUSTMENT_FACTOR = 1.8;
 export const DEFAULT_GAS_PRICE = "10000000000";
 export const DEFAULT_GAS = "auto";
-export const DEFAULT_HTTP_TIMEOUT = 2_000;
+export const DEFAULT_REQUEST_TIMEOUT = 2_000;
+export const DEFAULT_TOTAL_HTTP_TIME_LIMIT = 20_000;
 
 export const PLANET_APP_CONFIG: DeepPartial<AppConfig> = {
 	sedaChain: {

--- a/packages/config/src/models/node-config.ts
+++ b/packages/config/src/models/node-config.ts
@@ -2,7 +2,6 @@ import * as v from "valibot";
 import {
 	DEFAULT_BLOCK_LOCALHOST,
 	DEFAULT_FORCE_SYNC_VM,
-	DEFAULT_HTTP_TIMEOUT,
 	DEFAULT_LOG_ROTATION_ENABLED,
 	DEFAULT_LOG_ROTATION_LEVEL,
 	DEFAULT_LOG_ROTATION_MAX_FILES,
@@ -12,7 +11,9 @@ import {
 	DEFAULT_MAX_VM_LOGS_SIZE_BYTES,
 	DEFAULT_MAX_VM_RESULT_SIZE_BYTES,
 	DEFAULT_PROCESS_DR_INTERVAL,
+	DEFAULT_REQUEST_TIMEOUT,
 	DEFAULT_TERMINATE_AFTER_COMPLETION,
+	DEFAULT_TOTAL_HTTP_TIME_LIMIT,
 } from "../constants";
 
 export const NodeConfigSchema = v.object({
@@ -29,7 +30,8 @@ export const NodeConfigSchema = v.object({
 	logRotationLevel: v.optional(v.string(), DEFAULT_LOG_ROTATION_LEVEL),
 	logRotationMaxFiles: v.optional(v.string(), DEFAULT_LOG_ROTATION_MAX_FILES),
 	logRotationMaxSize: v.optional(v.string(), DEFAULT_LOG_ROTATION_MAX_SIZE),
-	httpTimeout: v.optional(v.number(), DEFAULT_HTTP_TIMEOUT),
+	requestTimeout: v.optional(v.number(), DEFAULT_REQUEST_TIMEOUT),
+	totalHttpTimeLimit: v.optional(v.number(), DEFAULT_TOTAL_HTTP_TIME_LIMIT),
 });
 
 export type NodeConfig = v.InferOutput<typeof NodeConfigSchema>;

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -8,7 +8,7 @@
 		"@cosmjs/crypto": "0.33.0",
 		"@seda-protocol/proto-messages": "0.5.0-dev.0",
 		"@seda-protocol/utils": "1.3.0",
-		"@seda-protocol/vm": "^1.0.6",
+		"@seda-protocol/vm": "^1.0.7",
 		"@sedaprotocol/overlay-ts-common": "0.0.0",
 		"@sedaprotocol/overlay-ts-config": "0.0.0",
 		"@sedaprotocol/overlay-ts-logger": "0.0.0",

--- a/packages/node/src/overlay-vm-adapter.ts
+++ b/packages/node/src/overlay-vm-adapter.ts
@@ -21,7 +21,8 @@ type Options = {
 	identityPrivateKey: Buffer;
 	gasPrice: bigint;
 	appConfig: AppConfig;
-	timeout: number;
+	requestTimeout: number;
+	totalHttpTimeLimit: number;
 };
 
 export class OverlayVmAdapter extends DataRequestVmAdapter {
@@ -33,7 +34,8 @@ export class OverlayVmAdapter extends DataRequestVmAdapter {
 		sedaChain: SedaChain,
 	) {
 		super({
-			timeout: options.timeout,
+			requestTimeout: options.requestTimeout,
+			totalHttpTimeLimit: options.totalHttpTimeLimit,
 		});
 
 		this.dataProxyRpcQueryClient = new sedachain.data_proxy.v1.QueryClientImpl(sedaChain.getProtobufRpcClient());

--- a/packages/node/src/tasks/execute-worker/sync-execute-worker.ts
+++ b/packages/node/src/tasks/execute-worker/sync-execute-worker.ts
@@ -44,7 +44,8 @@ function startWorker() {
 					dataRequestId: message.dataRequest.id,
 					gasPrice: message.dataRequest.gasPrice,
 					identityPrivateKey: message.identityPrivateKey,
-					timeout: message.appConfig.node.httpTimeout,
+					requestTimeout: message.appConfig.node.requestTimeout,
+					totalHttpTimeLimit: message.appConfig.node.totalHttpTimeLimit,
 				},
 				sedaChain.value,
 			);

--- a/packages/node/src/tasks/execute.ts
+++ b/packages/node/src/tasks/execute.ts
@@ -71,7 +71,8 @@ export async function executeDataRequest(
 				gasPrice: dataRequest.gasPrice,
 				identityPrivateKey,
 				appConfig,
-				timeout: appConfig.node.httpTimeout,
+				requestTimeout: appConfig.node.requestTimeout,
+				totalHttpTimeLimit: appConfig.node.totalHttpTimeLimit,
 			},
 			sedaChain,
 		);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,11 @@
 		// Some stricter flags (disabled by default)
 		"noUnusedLocals": false,
 		"noUnusedParameters": false,
-		"noPropertyAccessFromIndexSignature": false
+		"noPropertyAccessFromIndexSignature": false,
+		// Performance optimizations
+		"incremental": true,
+		"tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
+		"isolatedModules": true,
+		"preserveWatchOutput": true
 	}
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

users can mess up the permissions on the overlay node, this ensures all folders are readable and writeable. And a cherry on top we check all the cached WASM binaries that they can be read by the overlay node.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

closes #59 
