### PR TITLE
feat: only log dr results in debug mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "overlay-node-ts",
 	"module": "index.ts",
-	"version": "1.0.0-rc.13",
+	"version": "1.0.0-rc.14",
 	"type": "module",
 	"license": "AGPL-3.0",
 	"workspaces": [

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -2,7 +2,7 @@ import type { AppConfig } from "./models/app-config";
 import type { DeepPartial } from "./types";
 
 export const DEFAULT_IDENTITIES_AMOUNT = 1;
-
+export const DEFAULT_DEBUG = false;
 export const DEFAULT_FETCH_TASK_INTERVAL = 1_000;
 export const DEFAULT_IDENTITY_CHECK_INTERVAL = 20 * 60 * 1000; // 20 minutes in milliseconds
 export const DEFAULT_SLEEP_BETWEEN_FAILED_TX = 3_000; // 5 seconds in milliseconds

--- a/packages/config/src/models/node-config.ts
+++ b/packages/config/src/models/node-config.ts
@@ -1,6 +1,7 @@
 import * as v from "valibot";
 import {
 	DEFAULT_BLOCK_LOCALHOST,
+	DEFAULT_DEBUG,
 	DEFAULT_FORCE_SYNC_VM,
 	DEFAULT_LOG_ROTATION_ENABLED,
 	DEFAULT_LOG_ROTATION_LEVEL,
@@ -17,6 +18,7 @@ import {
 } from "../constants";
 
 export const NodeConfigSchema = v.object({
+	debug: v.optional(v.boolean(), DEFAULT_DEBUG),
 	forceSyncVm: v.optional(v.boolean(), DEFAULT_FORCE_SYNC_VM),
 	threadAmount: v.optional(v.number()),
 	terminateAfterCompletion: v.optional(v.boolean(), DEFAULT_TERMINATE_AFTER_COMPLETION),

--- a/packages/node/src/data-request-task.ts
+++ b/packages/node/src/data-request-task.ts
@@ -225,9 +225,11 @@ export class DataRequestTask extends EventEmitter<EventMap> {
 			return;
 		}
 
-		logger.debug(`Raw results: ${JSONStringify(vmResult.value)}`, {
-			id: this.name,
-		});
+		if (this.appConfig.node.debug) {
+			logger.debug(`Raw results: ${JSONStringify(vmResult.value)}`, {
+				id: this.name,
+			});
+		}
 
 		this.executionResult = Maybe.just<ExecutionResult>({
 			stderr: [vmResult.value.stderr],


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Only show data request results in the overlay node on debug mode. It's not needed for the overlay operator to see.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* add a new debug option that by default doesn't show the raw results of an execution
