### PR TITLE
Bump vm version to v1.0.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -86,7 +86,7 @@
         "@hono/node-server": "1.14.1",
         "@seda-protocol/proto-messages": "0.5.0-dev.0",
         "@seda-protocol/utils": "1.3.0",
-        "@seda-protocol/vm": "^1.0.8",
+        "@seda-protocol/vm": "^1.0.9",
         "@sedaprotocol/core-contract-schema": "0.0.0",
         "@sedaprotocol/overlay-ts-common": "0.0.0",
         "@sedaprotocol/overlay-ts-config": "0.0.0",
@@ -246,7 +246,7 @@
 
     "@seda-protocol/utils": ["@seda-protocol/utils@1.3.0", "", { "peerDependencies": { "true-myth": "^8.0.1", "valibot": "^0.42.1" } }, "sha512-6/2qt7+TUQcezWwGHB3QdJZLfd8cRzS58UpdbqzAtRmy4jsM7AR5bcKqNrIjNNBIB/rX29ObaLjT3JK3G3Khkg=="],
 
-    "@seda-protocol/vm": ["@seda-protocol/vm@1.0.8", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.0", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-cASujXl7xeVukn2GFlsHA15iB3odNsBOxIaBwpKpr2tV2/PSbpEt+pxQYXfbxAxz726SIBRLuR4S35x6HnFayA=="],
+    "@seda-protocol/vm": ["@seda-protocol/vm@1.0.9", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.0", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-FdUNhZUaQiQ1xvuRGkPd9mM4xEAI8r0bgkdZgjcs9KIwUxHX8mIBdlbTDy9XHEsNwDSEL3PYBpM8riYtVXz+QQ=="],
 
     "@seda-protocol/wasm-metering-ts": ["@seda-protocol/wasm-metering-ts@2.0.0", "", { "dependencies": { "buffer-pipe": "^0.0.5", "leb128": "^0.0.5", "warp-isomorphic": "^1.0.7" }, "peerDependencies": { "typescript": "^5.7.3" } }, "sha512-EA/xNeVG/yKiXw/zP+QL0q/Oq7cpee2ydpfmfOXMVgU0emEX2aHuSv1lHCNuw4vNVuN7sjzEUXKwUlkAAmBvaA=="],
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -8,7 +8,7 @@
 		"@cosmjs/crypto": "0.33.0",
 		"@seda-protocol/proto-messages": "0.5.0-dev.0",
 		"@seda-protocol/utils": "1.3.0",
-		"@seda-protocol/vm": "^1.0.8",
+		"@seda-protocol/vm": "^1.0.9",
 		"@sedaprotocol/overlay-ts-common": "0.0.0",
 		"@sedaprotocol/overlay-ts-config": "0.0.0",
 		"@sedaprotocol/overlay-ts-logger": "0.0.0",


### PR DESCRIPTION
## Motivation

Fixes issue where insufficient data proxy gas was not properly communicated back to the user.

## Explanation of Changes

N.A.

## Testing

See VM PR: https://github.com/sedaprotocol/seda-sdk/pull/173

## Related PRs and Issues

https://github.com/sedaprotocol/seda-sdk/pull/173
