### PR TITLE
fix: fix issue where overlay nodes would commit on a already revealin…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "overlay-node-ts",
 	"module": "index.ts",
-	"version": "1.0.0-rc.15",
+	"version": "1.0.0-rc.16",
 	"type": "module",
 	"license": "AGPL-3.0",
 	"workspaces": [

--- a/packages/node/src/models/data-request-pool.ts
+++ b/packages/node/src/models/data-request-pool.ts
@@ -79,6 +79,15 @@ export class DataRequestPool {
 		return this.identityDataRequests.values();
 	}
 
+	/**
+	 * Check if the data request is being processed by any identity
+	 * @param drId - The data request id
+	 * @returns true if the data request is being processed by any identity, false otherwise
+	 */
+	isDrBeingProcessed(drId: DataRequestId): boolean {
+		return this.identityDataRequests.values().some((identityDataRequest) => identityDataRequest.drId === drId);
+	}
+
 	insertDataRequest(dataRequest: DataRequest) {
 		this.items.set(dataRequest.id, dataRequest);
 	}

--- a/packages/node/src/tasks/fetch.ts
+++ b/packages/node/src/tasks/fetch.ts
@@ -4,7 +4,7 @@ import type { AppConfig } from "@sedaprotocol/overlay-ts-config";
 import { logger } from "@sedaprotocol/overlay-ts-logger";
 import { EventEmitter } from "eventemitter3";
 import { Maybe, Result, type Unit } from "true-myth";
-import type { DataRequest } from "../models/data-request";
+import { type DataRequest, isDrInRevealStage } from "../models/data-request";
 import type { DataRequestPool } from "../models/data-request-pool";
 import { getDataRequests } from "../services/get-data-requests";
 
@@ -42,6 +42,15 @@ export class FetchTask extends EventEmitter<EventMap> {
 			if (this.pool.hasDataRequest(dataRequest.id)) {
 				// Always update the pool
 				this.pool.insertDataRequest(dataRequest);
+				continue;
+			}
+
+			// When the data request is in the reveal stage we can't process it
+			// other nodes will take care of it
+			if (isDrInRevealStage(dataRequest)) {
+				logger.debug("Skipping fetched data request in reveal stage", {
+					id: dataRequest.id,
+				});
 				continue;
 			}
 


### PR DESCRIPTION
…g DR

<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Prevent the node from trying to commit when it knows already that the data request is in the reveal stage

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* Prevent committs from happening on in reveal stage drs
* Skip eligibility check and even remove drs that are not processing and in reveal stage
* Skip storing data requests which are in reveal stage

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Node runs as normal
