### PR TITLE
FetchTask health tracker

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
         "@hono/node-server": "1.14.1",
         "@seda-protocol/proto-messages": "0.5.0-dev.0",
         "@seda-protocol/utils": "1.3.0",
-        "@seda-protocol/vm": "1.0.11",
+        "@seda-protocol/vm": "1.0.12",
         "@sedaprotocol/core-contract-schema": "0.0.0",
         "@sedaprotocol/overlay-ts-common": "0.0.0",
         "@sedaprotocol/overlay-ts-config": "0.0.0",
@@ -217,8 +217,6 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.4", "", { "os": "win32", "cpu": "x64" }, "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ=="],
-
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.13.4", "", { "dependencies": { "@grpc/proto-loader": "^0.7.13", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg=="],
 
@@ -358,9 +356,7 @@
 
     "brorand": ["brorand@1.1.0", "", {}, "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="],
 
-    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
-    "buffer-pipe": ["buffer-pipe@0.0.5", "", { "dependencies": { "safe-buffer": "^5.2.0" } }, "sha512-a6kQxHM27rLrDpVFCKk9iirHKQU2fukg/j3XqIIOoc1rT/W5kp+KsIQmff6dJ7I3ErxmAasetarkeSG1iqGpkA=="],
+    "buffer-pipe": ["buffer-pipe@0.0.3", "", { "dependencies": { "safe-buffer": "^5.1.2" } }, "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA=="],
 
     "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
 
@@ -461,8 +457,6 @@
     "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
 
     "hono": ["hono@4.7.10", "", {}, "sha512-QkACju9MiN59CKSY5JsGZCYmPZkA6sIW6OFCUp7qDjZu6S6KHtJHhAc9Uy9mV9F8PJ1/HQ3ybZF2yjCa/73fvQ=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -610,8 +604,6 @@
 
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
-    "undici": ["undici@5.28.5", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA=="],
-
     "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
@@ -623,8 +615,6 @@
     "uwasi": ["uwasi@1.4.1", "", {}, "sha512-QOT8tBsSwG7dm99Ry4X2gqsEEq4B6Q3eMSyazMQw7fd6XwBKPvBnxgpAksDRLZBMIp+F1wChhKPon20HQK6i0Q=="],
 
     "valibot": ["valibot@0.42.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw=="],
-
-    "warp-isomorphic": ["warp-isomorphic@1.0.7", "", { "dependencies": { "buffer": "^6.0.3", "undici": "^5.19.1" } }, "sha512-fXHbUXwdYqPm9fRPz8mjv5ndPco09aMQuTe4kXfymzOq8V6F3DLsg9cIafxvjms9/mc6eijzkLBJ63yjEENEjA=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
@@ -660,25 +650,15 @@
 
     "@seda-protocol/vm/true-myth": ["true-myth@7.4.0", "", {}, "sha512-HRaZmfP3Y6JY2qb6M2gndkfb8dpwk6M4xSWD3i1JXUabmur9SaBNcf+oZ1ARU+51qoDVLcLCsjKN9UQwiW2ojQ=="],
 
-    "@sedaprotocol/overlay-ts-node/@seda-protocol/vm": ["@seda-protocol/vm@1.0.11", "", { "dependencies": { "@noble/hashes": "1.4.0", "@noble/secp256k1": "2.1.0", "@seda-protocol/utils": "^1.0.0", "@seda-protocol/wasm-metering-ts": "^2.0.0", "true-myth": "^7.3.0", "uwasi": "^1.4.1" } }, "sha512-yEZoXJF0BqIINA9z7rb8S+jZFWVT4nwYUI288p5P9iG/s3iDS0R9JcRIrotznodIEGE66KVjLtUypsoyPMqyJA=="],
-
     "ansi-styles/color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "duplexer2/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "elliptic/bn.js": ["bn.js@4.12.1", "", {}, "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="],
 
-    "leb128/buffer-pipe": ["buffer-pipe@0.0.3", "", { "dependencies": { "safe-buffer": "^5.1.2" } }, "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA=="],
-
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
     "tsx/esbuild": ["esbuild@0.25.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.0", "@esbuild/android-arm": "0.25.0", "@esbuild/android-arm64": "0.25.0", "@esbuild/android-x64": "0.25.0", "@esbuild/darwin-arm64": "0.25.0", "@esbuild/darwin-x64": "0.25.0", "@esbuild/freebsd-arm64": "0.25.0", "@esbuild/freebsd-x64": "0.25.0", "@esbuild/linux-arm": "0.25.0", "@esbuild/linux-arm64": "0.25.0", "@esbuild/linux-ia32": "0.25.0", "@esbuild/linux-loong64": "0.25.0", "@esbuild/linux-mips64el": "0.25.0", "@esbuild/linux-ppc64": "0.25.0", "@esbuild/linux-riscv64": "0.25.0", "@esbuild/linux-s390x": "0.25.0", "@esbuild/linux-x64": "0.25.0", "@esbuild/netbsd-arm64": "0.25.0", "@esbuild/netbsd-x64": "0.25.0", "@esbuild/openbsd-arm64": "0.25.0", "@esbuild/openbsd-x64": "0.25.0", "@esbuild/sunos-x64": "0.25.0", "@esbuild/win32-arm64": "0.25.0", "@esbuild/win32-ia32": "0.25.0", "@esbuild/win32-x64": "0.25.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw=="],
-
-    "@sedaprotocol/overlay-ts-node/@seda-protocol/vm/@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
-
-    "@sedaprotocol/overlay-ts-node/@seda-protocol/vm/@seda-protocol/wasm-metering-ts": ["@seda-protocol/wasm-metering-ts@2.0.0", "", { "dependencies": { "buffer-pipe": "^0.0.5", "leb128": "^0.0.5", "warp-isomorphic": "^1.0.7" }, "peerDependencies": { "typescript": "^5.7.3" } }, "sha512-EA/xNeVG/yKiXw/zP+QL0q/Oq7cpee2ydpfmfOXMVgU0emEX2aHuSv1lHCNuw4vNVuN7sjzEUXKwUlkAAmBvaA=="],
-
-    "@sedaprotocol/overlay-ts-node/@seda-protocol/vm/true-myth": ["true-myth@7.4.0", "", {}, "sha512-HRaZmfP3Y6JY2qb6M2gndkfb8dpwk6M4xSWD3i1JXUabmur9SaBNcf+oZ1ARU+51qoDVLcLCsjKN9UQwiW2ojQ=="],
 
     "ansi-styles/color-convert/color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 

--- a/packages/cli/src/commands/tools/available-executors.ts
+++ b/packages/cli/src/commands/tools/available-executors.ts
@@ -27,8 +27,8 @@ export const availableExecutors = populateWithCommonOptions(new Command("availab
 			const publicKey = staker.publicKey.toString("hex");
 			return {
 				publicKey,
-				tokensStaked: staker.tokensStaked,
-				tokensPendingWithdrawal: staker.tokensPendingWithdrawal,
+				tokensStaked: staker.tokensStaked.toString(),
+				tokensPendingWithdrawal: staker.tokensPendingWithdrawal.toString(),
 				memo: staker.memo.unwrapOr(Buffer.alloc(0)).toString("utf-8"),
 			};
 		});

--- a/packages/cli/src/commands/tools/execute-oracle-program.ts
+++ b/packages/cli/src/commands/tools/execute-oracle-program.ts
@@ -81,7 +81,6 @@ export const executeOracleProgram = populateWithCommonOptions(new Command("execu
 				gasPrice: BigInt(gasPrice),
 				identityPrivateKey,
 				appConfig: config.value,
-				requestTimeout: config.value.node.requestTimeout,
 				totalHttpTimeLimit: config.value.node.totalHttpTimeLimit,
 			},
 			sedaChain,

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -34,6 +34,8 @@ export const DEFAULT_MIN_SEDA_PER_ACCOUNT = 1_000_000_000_000_000_000n; // 1 SED
 export const DEFAULT_LOG_LEVEL = "debug";
 export const DEFAULT_FETCH_LIMIT = 20;
 export const DEFAULT_OFFLINE_ELIGIBILITY = true;
+export const DEFAULT_FETCH_FAILURE_THRESHOLD = 0.2;
+export const DEFAULT_FETCH_COUNT_REFRESH_INTERVAL = 300000; // 5 minutes in milliseconds
 
 export const PLANET_APP_CONFIG: DeepPartial<AppConfig> = {
 	sedaChain: {

--- a/packages/config/src/constants.ts
+++ b/packages/config/src/constants.ts
@@ -27,7 +27,6 @@ export const DEFAULT_HTTP_SERVER_PORT = 3000;
 export const DEFAULT_ADJUSTMENT_FACTOR = 2;
 export const DEFAULT_GAS_PRICE = "10000000000";
 export const DEFAULT_GAS = "auto";
-export const DEFAULT_REQUEST_TIMEOUT = 2_000;
 export const DEFAULT_TOTAL_HTTP_TIME_LIMIT = 20_000;
 export const DEFAULT_MAX_REVEAL_SIZE = 24_000; // 24KB (should be divided by the replication factor)
 export const DEFAULT_ACCOUNT_AMOUNTS = 10;

--- a/packages/config/src/models/node-config.ts
+++ b/packages/config/src/models/node-config.ts
@@ -2,6 +2,8 @@ import * as v from "valibot";
 import {
 	DEFAULT_BLOCK_LOCALHOST,
 	DEFAULT_DEBUG,
+	DEFAULT_FETCH_COUNT_REFRESH_INTERVAL,
+	DEFAULT_FETCH_FAILURE_THRESHOLD,
 	DEFAULT_FETCH_LIMIT,
 	DEFAULT_FORCE_SYNC_VM,
 	DEFAULT_LOG_LEVEL,
@@ -36,6 +38,8 @@ export const NodeConfigSchema = v.object({
 	totalHttpTimeLimit: v.optional(v.number(), DEFAULT_TOTAL_HTTP_TIME_LIMIT),
 	drFetchLimit: v.optional(v.number(), DEFAULT_FETCH_LIMIT),
 	offlineEligibility: v.optional(v.boolean(), DEFAULT_OFFLINE_ELIGIBILITY),
+	fetchFailureThreshold: v.optional(v.number(), DEFAULT_FETCH_FAILURE_THRESHOLD),
+	fetchCountRefreshInterval: v.optional(v.number(), DEFAULT_FETCH_COUNT_REFRESH_INTERVAL),
 });
 
 export type NodeConfig = v.InferOutput<typeof NodeConfigSchema>;

--- a/packages/config/src/models/node-config.ts
+++ b/packages/config/src/models/node-config.ts
@@ -14,7 +14,6 @@ import {
 	DEFAULT_MAX_VM_LOGS_SIZE_BYTES,
 	DEFAULT_OFFLINE_ELIGIBILITY,
 	DEFAULT_PROCESS_DR_INTERVAL,
-	DEFAULT_REQUEST_TIMEOUT,
 	DEFAULT_TERMINATE_AFTER_COMPLETION,
 	DEFAULT_TOTAL_HTTP_TIME_LIMIT,
 } from "../constants";
@@ -34,7 +33,6 @@ export const NodeConfigSchema = v.object({
 	logRotationLevel: v.optional(v.string(), DEFAULT_LOG_ROTATION_LEVEL),
 	logRotationMaxFiles: v.optional(v.string(), DEFAULT_LOG_ROTATION_MAX_FILES),
 	logRotationMaxSize: v.optional(v.string(), DEFAULT_LOG_ROTATION_MAX_SIZE),
-	requestTimeout: v.optional(v.number(), DEFAULT_REQUEST_TIMEOUT),
 	totalHttpTimeLimit: v.optional(v.number(), DEFAULT_TOTAL_HTTP_TIME_LIMIT),
 	drFetchLimit: v.optional(v.number(), DEFAULT_FETCH_LIMIT),
 	offlineEligibility: v.optional(v.boolean(), DEFAULT_OFFLINE_ELIGIBILITY),

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -8,7 +8,7 @@
 		"@cosmjs/crypto": "0.33.0",
 		"@seda-protocol/proto-messages": "0.5.0-dev.0",
 		"@seda-protocol/utils": "1.3.0",
-		"@seda-protocol/vm": "1.0.11",
+		"@seda-protocol/vm": "1.0.12",
 		"@sedaprotocol/overlay-ts-common": "0.0.0",
 		"@sedaprotocol/overlay-ts-config": "0.0.0",
 		"@sedaprotocol/overlay-ts-logger": "0.0.0",

--- a/packages/node/src/http-server/routes/api.ts
+++ b/packages/node/src/http-server/routes/api.ts
@@ -13,6 +13,8 @@ export function createApi(mainTask: MainTask) {
 
 			txStats: mainTask.getTransactionStats(),
 
+			isFetchTaskHealthy: mainTask.isFetchTaskHealthy(),
+
 			activeIdentities: Array.from(mainTask.identityPool.all()).map(({ identityId, enabled }) => ({
 				identityId,
 				enabled,

--- a/packages/node/src/overlay-vm-adapter.ts
+++ b/packages/node/src/overlay-vm-adapter.ts
@@ -28,7 +28,6 @@ type Options = {
 	identityPrivateKey: Buffer;
 	gasPrice: bigint;
 	appConfig: AppConfig;
-	requestTimeout: number;
 	totalHttpTimeLimit: number;
 };
 
@@ -45,7 +44,6 @@ export class OverlayVmAdapter extends DataRequestVmAdapter {
 		private traceId: string,
 	) {
 		super({
-			requestTimeout: options.requestTimeout,
 			totalHttpTimeLimit: options.totalHttpTimeLimit,
 		});
 

--- a/packages/node/src/tasks/execute-worker/sync-execute-worker.ts
+++ b/packages/node/src/tasks/execute-worker/sync-execute-worker.ts
@@ -49,7 +49,6 @@ function startWorker() {
 					eligibilityHeight: BigInt(message.eligibilityHeight),
 					gasPrice: message.dataRequest.gasPrice,
 					identityPrivateKey: message.identityPrivateKey,
-					requestTimeout: message.appConfig.node.requestTimeout,
 					totalHttpTimeLimit: message.appConfig.node.totalHttpTimeLimit,
 				},
 				sedaChain.value,

--- a/packages/node/src/tasks/execute.ts
+++ b/packages/node/src/tasks/execute.ts
@@ -79,7 +79,6 @@ export async function executeDataRequest(
 				identityPrivateKey,
 				eligibilityHeight,
 				appConfig,
-				requestTimeout: appConfig.node.requestTimeout,
 				totalHttpTimeLimit: appConfig.node.totalHttpTimeLimit,
 			},
 			sedaChain,

--- a/packages/node/src/tasks/main.ts
+++ b/packages/node/src/tasks/main.ts
@@ -191,4 +191,8 @@ export class MainTask {
 			sedaChain: this.sedaChain.getTransactionStats(),
 		};
 	}
+
+	isFetchTaskHealthy() {
+		return this.fetchTask.isFetchTaskHealthy;
+	}
 }


### PR DESCRIPTION
## Motivation

Add a simple tracker variable `isFetchTaskHealthy` to `FetchTask` that turns false if more than a given percentage (20% by default) of fetch attempts in a given interval (5 minutes by default) fail. Initially, this variable is undefined and is absent from the health endpoint http://localhost:3000/api/health. Afterwards, it gets updated at every interval to indicate the health of FetchTask. 

## Testing

Tested on planet with logs.
Example output of http://localhost:3000/api/health
```
{
  "activelyExecutingSize": 0,
  "eligibleButWaitingForExecutionSize": 0,
  "dataRequestPoolSize": 0,
  "completedDataRequests": 0,
  "txStats": {
    "sedaChain": {
      "successCount": 0,
      "failureCount": 0,
      "pendingCount": 0,
      "retryCount": 0
    }
  },
  "isFetchTaskHealthy": true,
...
}
```

Closes #78 